### PR TITLE
feat: vibrant indigo color scheme (#6366F1)

### DIFF
--- a/index.css
+++ b/index.css
@@ -11,9 +11,9 @@ html { scroll-behavior: smooth; }
 /* ─── LIGHT THEME ────────────────────────────────────────── */
 :root,
 [data-theme="light"] {
-    --main-color: #8EA7E9;
-    --main-color-dark: #6A89D4;
-    --accent: #EF233C;
+    --main-color: #6366F1;
+    --main-color-dark: #4F46E5;
+    --accent: #F43F5E;
     --bg: #ffffff;
     --card-bg: #ffffff;
     --header-bg: rgba(255, 255, 255, 0.88);
@@ -21,23 +21,25 @@ html { scroll-behavior: smooth; }
     --text-dark: #1a1a2e;
     --text-light: #666;
     --border: #e0e0e0;
-    --shadow: 0 4px 20px rgba(142, 167, 233, 0.15);
-    --shadow-hover: 0 8px 32px rgba(142, 167, 233, 0.35);
+    --shadow: 0 4px 20px rgba(99, 102, 241, 0.12);
+    --shadow-hover: 0 8px 32px rgba(99, 102, 241, 0.28);
     --transition: all 0.3s ease;
     --section-gap: 5rem;
 }
 
 /* ─── DARK THEME ──────────────────────────────────────────── */
 [data-theme="dark"] {
-    --bg: #0d0d1a;
-    --card-bg: #15152a;
-    --header-bg: rgba(13, 13, 26, 0.90);
-    --footer-bg: #0a0a16;
+    --main-color: #818CF8;
+    --main-color-dark: #6366F1;
+    --bg: #0d0b1e;
+    --card-bg: #13112a;
+    --header-bg: rgba(13, 11, 30, 0.92);
+    --footer-bg: #0a0918;
     --text-dark: #e8e8f2;
     --text-light: #9090b0;
-    --border: #2a2a44;
+    --border: #2d2a50;
     --shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
-    --shadow-hover: 0 8px 32px rgba(142, 167, 233, 0.25);
+    --shadow-hover: 0 8px 32px rgba(99, 102, 241, 0.25);
 }
 
 /* ─── BASE ─────────────────────────────────────────────────── */
@@ -81,7 +83,7 @@ header.scrolled {
     left: 0;
     height: 2.5px;
     width: 0%;
-    background: linear-gradient(90deg, var(--main-color), #c77dff, var(--accent), var(--main-color));
+    background: linear-gradient(90deg, var(--main-color), #a78bfa, var(--accent), var(--main-color));
     background-size: 300% auto;
     animation: gradientFlow 4s linear infinite;
     transition: width 0.1s linear;
@@ -131,7 +133,7 @@ header.scrolled {
 
 .logo-link:hover .logo-badge {
     transform: rotate(-8deg) scale(1.1);
-    box-shadow: 0 4px 16px rgba(142, 167, 233, 0.55);
+    box-shadow: 0 4px 16px rgba(99, 102, 241, 0.55);
 }
 
 .logo-name {
@@ -162,13 +164,13 @@ header.scrolled {
 }
 
 #nav3 li a:not(.nav-cta):hover {
-    background: rgba(142, 167, 233, 0.1);
+    background: rgba(99, 102, 241, 0.1);
     color: var(--main-color);
 }
 
 #nav3 li a.active:not(.nav-cta) {
     color: var(--main-color);
-    background: rgba(142, 167, 233, 0.1);
+    background: rgba(99, 102, 241, 0.1);
     font-weight: 400;
 }
 
@@ -180,13 +182,13 @@ header.scrolled {
     border-radius: 30px !important;
     font-weight: 500 !important;
     letter-spacing: 0.02em;
-    box-shadow: 0 2px 14px rgba(142, 167, 233, 0.35);
+    box-shadow: 0 2px 14px rgba(99, 102, 241, 0.35);
     transition: box-shadow 0.3s ease, transform 0.2s ease !important;
     margin-left: 0.5rem;
 }
 
 .nav-cta:hover {
-    box-shadow: 0 4px 22px rgba(142, 167, 233, 0.6) !important;
+    box-shadow: 0 4px 22px rgba(99, 102, 241, 0.6) !important;
     transform: translateY(-2px) scale(1.04) !important;
 }
 
@@ -321,7 +323,7 @@ header.scrolled {
 }
 
 .sidebar li a:not(.sidebar-cta):hover {
-    background: rgba(142, 167, 233, 0.1);
+    background: rgba(99, 102, 241, 0.1);
     color: var(--main-color);
     padding-left: 2rem;
     border-left-color: var(--main-color);
@@ -353,7 +355,7 @@ header.scrolled {
     padding: 0.7rem 1rem !important;
     font-weight: 500 !important;
     border-left: none !important;
-    box-shadow: 0 2px 14px rgba(142, 167, 233, 0.35);
+    box-shadow: 0 2px 14px rgba(99, 102, 241, 0.35);
 }
 
 .sidebar-cta:hover {
@@ -380,8 +382,8 @@ header.scrolled {
     padding: 4rem 2rem;
     background-color: var(--bg);
     background-image:
-        radial-gradient(ellipse at 15% 50%, rgba(142, 167, 233, 0.1) 0%, transparent 55%),
-        radial-gradient(ellipse at 85% 20%, rgba(142, 167, 233, 0.07) 0%, transparent 50%);
+        radial-gradient(ellipse at 15% 50%, rgba(99, 102, 241, 0.08) 0%, transparent 55%),
+        radial-gradient(ellipse at 85% 20%, rgba(99, 102, 241, 0.05) 0%, transparent 50%);
     transition: background-color 0.35s ease;
 }
 
@@ -390,13 +392,13 @@ header.scrolled {
     height: 320px;
     width: 320px;
     object-fit: cover;
-    box-shadow: 0 0 0 6px var(--bg), 0 0 0 9px var(--main-color), 0 16px 48px rgba(142, 167, 233, 0.4);
+    box-shadow: 0 0 0 6px var(--bg), 0 0 0 9px var(--main-color), 0 16px 48px rgba(99, 102, 241, 0.35);
     transition: transform 0.4s ease, box-shadow 0.4s ease;
 }
 
 #profile-pic:hover {
     transform: scale(1.03);
-    box-shadow: 0 0 0 6px var(--bg), 0 0 0 9px var(--main-color-dark), 0 20px 56px rgba(142, 167, 233, 0.5);
+    box-shadow: 0 0 0 6px var(--bg), 0 0 0 9px var(--main-color-dark), 0 20px 56px rgba(99, 102, 241, 0.5);
 }
 
 #about-me {
@@ -498,7 +500,7 @@ section { text-align: center; padding: 4.5rem 2rem 1.5rem; }
     transition: box-shadow 0.4s ease;
 }
 
-#about-me-image:hover { box-shadow: 0 8px 32px rgba(142, 167, 233, 0.4); }
+#about-me-image:hover { box-shadow: 0 8px 32px rgba(99, 102, 241, 0.35); }
 
 #experience-education-inner { display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 2rem; max-width: 580px; }
 #experience-education-outer { display: flex; flex-wrap: wrap; justify-content: center; gap: 1.5rem; }


### PR DESCRIPTION
## New Color Scheme — Vibrant Indigo

Replaces the old muted periwinkle blue (`#8EA7E9`) with a vibrant **Indigo** palette used by top sites like Linear, Vercel, and Notion.

### Color Token Changes

| Token | Old | New |
|---|---|---|
| `--main-color` (light) | `#8EA7E9` | `#6366F1` |
| `--main-color-dark` (light) | `#6A89D4` | `#4F46E5` |
| `--main-color` (dark mode) | same as light | `#818CF8` (lighter for visibility) |
| `--main-color-dark` (dark mode) | same as light | `#6366F1` |
| `--accent` | `#EF233C` | `#F43F5E` rose red |
| Dark background | `#0d0d1a` | `#0d0b1e` purple-tinted |
| Dark card | `#15152a` | `#13112a` |
| Dark border | `#2a2a44` | `#2d2a50` |

### What's updated
- All `rgba(142, 167, 233, ...)` shadow and glow references updated to `rgba(99, 102, 241, ...)`
- Scroll progress bar gradient updated to indigo → violet → rose
- Profile picture ring glow updated
- Card hover shadows updated
- Dark mode now gets its own lighter `--main-color` override for better contrast