### PR TITLE
feat: blog cards — read time + real categories/tags

### DIFF
--- a/index.css
+++ b/index.css
@@ -158,7 +158,6 @@ em   { font-style: italic; }
 .btn-brutal--white { background: var(--white);  color: var(--black); }
 .btn-brutal--green { background: var(--green);  color: var(--black); }
 
-/* Hero-context button overrides — white bg btn reads as accent on dark */
 .hero .btn-brutal--white {
     background: transparent;
     color: var(--white);
@@ -183,7 +182,6 @@ em   { font-style: italic; }
     box-shadow: 10px 10px 0px rgba(204,255,0,0.5);
 }
 
-/* Wobble on hover */
 .wobble-btn:hover { animation: wobble 0.5s ease-in-out; }
 
 
@@ -256,9 +254,7 @@ em   { font-style: italic; }
     text-decoration: none;
 }
 
-.nav-links li a.pill-link:hover {
-    transform: translateY(-1px);
-}
+.nav-links li a.pill-link:hover { transform: translateY(-1px); }
 
 .pill-hover-circle {
     position: absolute;
@@ -287,21 +283,8 @@ em   { font-style: italic; }
     transition: transform 0.2s ease;
 }
 
-.pill-label {
-    position: relative;
-    z-index: 2;
-    color: #1a1a1a;
-}
-
-.pill-label-hover {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    text-align: center;
-    z-index: 3;
-    color: #fff;
-}
+.pill-label          { position: relative; z-index: 2; color: #1a1a1a; }
+.pill-label-hover    { position: absolute; left: 0; top: 0; width: 100%; text-align: center; z-index: 3; color: #fff; }
 
 .nav-links li a.pill-link.active {
     background: #111;
@@ -310,14 +293,8 @@ em   { font-style: italic; }
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.08) inset;
 }
 
-.nav-links li a.pill-link.active .pill-label {
-    color: #fff;
-}
-
-.nav-links li a.pill-link.active .pill-label-hover {
-    opacity: 1;
-    transform: translateY(0);
-}
+.nav-links li a.pill-link.active .pill-label       { color: #fff; }
+.nav-links li a.pill-link.active .pill-label-hover { opacity: 1; transform: translateY(0); }
 
 .nav-cta-pill {
     font-family: var(--font-head);
@@ -341,7 +318,6 @@ em   { font-style: italic; }
     box-shadow: 4px 4px 0px var(--purple);
 }
 
-/* hamburger */
 .nav-hamburger {
     display: none;
     flex-direction: column;
@@ -480,11 +456,8 @@ em   { font-style: italic; }
     opacity: 0;
 }
 
-.hero-cursor-glow.visible {
-    opacity: 1;
-}
+.hero-cursor-glow.visible { opacity: 1; }
 
-/* decorative blobs */
 .hero-blob {
     position: absolute;
     width: 480px;
@@ -499,7 +472,6 @@ em   { font-style: italic; }
 .hero-blob--purple { background: var(--purple); top: -120px; right: 8%; opacity: 0.38; }
 .hero-blob--pink   { background: var(--pink);   bottom: -100px; left: 4%; opacity: 0.28; }
 
-/* ── Hero left ──────────────────────────────────────────────── */
 .hero-left {
     position: relative;
     z-index: 1;
@@ -574,7 +546,7 @@ em   { font-style: italic; }
 
 @keyframes roleCursorBlink {
     0%, 100% { opacity: 1; }
-    50% { opacity: 0.2; }
+    50%       { opacity: 0.2; }
 }
 
 .hero-cta-row {
@@ -615,7 +587,6 @@ em   { font-style: italic; }
     box-shadow: 4px 6px 0px rgba(204,255,0,0.5);
 }
 
-/* ── Hero right ─────────────────────────────────────────────── */
 .hero-right {
     position: relative;
     z-index: 1;
@@ -626,7 +597,6 @@ em   { font-style: italic; }
     animation: fadeUp 0.65s 0.22s ease both;
 }
 
-/* ── Stickers ───────────────────────────────────────────────── */
 .sticker {
     position: absolute;
     font-size: 1.75rem;
@@ -649,10 +619,9 @@ em   { font-style: italic; }
 .sticker-4 { bottom: 8%;  right: -2%; animation-duration: 8s;  animation-delay: 2s;   transform: rotate(5deg);  }
 .sticker-5 { top: 50%;  left: -9%;  animation-duration: 7s;   animation-delay: 1.4s; transform: rotate(-4deg); }
 
-.sticker-about-1 { top: -14px; right: -12px; animation-duration: 6.2s;  animation-delay: 0.3s; z-index: 2; font-size: 1.4rem; width: 46px; height: 46px; }
-.sticker-about-2 { bottom: 8px; left: -12px; animation-duration: 7.2s;  animation-delay: 1.1s; z-index: 2; font-size: 1.4rem; width: 46px; height: 46px; }
+.sticker-about-1 { top: -14px; right: -12px; animation-duration: 6.2s; animation-delay: 0.3s; z-index: 2; font-size: 1.4rem; width: 46px; height: 46px; }
+.sticker-about-2 { bottom: 8px; left: -12px; animation-duration: 7.2s; animation-delay: 1.1s; z-index: 2; font-size: 1.4rem; width: 46px; height: 46px; }
 
-/* ── Phone Mockup ───────────────────────────────────────────── */
 .phone-mockup {
     position: relative;
     z-index: 1;
@@ -744,11 +713,11 @@ em   { font-style: italic; }
 
 .phone-post:hover { transform: translateX(4px); }
 
-.phone-post--aws { background: #fff8e1; transform: rotate(-0.5deg); }
-.phone-post--tf  { background: #f0e6ff; transform: rotate(0.7deg);  }
-.phone-post--k8s { background: #e6f0ff; transform: rotate(-1deg);   }
-.phone-post--azure { background: #e8f3ff; transform: rotate(0.2deg); }
-.phone-post--dev { background: #ffe6f5; transform: rotate(0.5deg);  }
+.phone-post--aws   { background: #fff8e1; transform: rotate(-0.5deg); }
+.phone-post--tf    { background: #f0e6ff; transform: rotate(0.7deg);  }
+.phone-post--k8s   { background: #e6f0ff; transform: rotate(-1deg);   }
+.phone-post--azure { background: #e8f3ff; transform: rotate(0.2deg);  }
+.phone-post--dev   { background: #ffe6f5; transform: rotate(0.5deg);  }
 
 .phone-post-icon { font-size: 1.35rem; flex-shrink: 0; }
 
@@ -930,7 +899,6 @@ em   { font-style: italic; }
     margin: 0 auto;
 }
 
-/* ── Individual bento cards ─ */
 .bento-card {
     background: var(--white);
     border: var(--border);
@@ -943,7 +911,6 @@ em   { font-style: italic; }
     transition:
         transform   0.35s var(--bounce),
         box-shadow  0.35s var(--bounce);
-    /* scroll entrance */
     opacity: 0;
 }
 
@@ -957,22 +924,12 @@ em   { font-style: italic; }
     box-shadow: var(--shadow-lg);
 }
 
-/* Card A — AWS, 7 cols, light gray */
-.bento-card--a { grid-column: span 7; background: var(--gray); }
+.bento-card--a { grid-column: span 7;  background: var(--gray); }
+.bento-card--b { grid-column: span 5;  background: var(--black); color: var(--white); }
+.bento-card--c { grid-column: span 12; background: var(--pink);  color: var(--white); }
+.bento-card--d { grid-column: span 5;  background: var(--white); }
+.bento-card--e { grid-column: span 7;  background: var(--black); color: var(--white); }
 
-/* Card B — DevOps Toolkit, 5 cols, black */
-.bento-card--b { grid-column: span 5; background: var(--black); color: var(--white); }
-
-/* Card C — Certs, 12 cols, electric orange */
-.bento-card--c { grid-column: span 12; background: var(--pink); color: var(--white); }
-
-/* Card D — Azure, 5 cols, white */
-.bento-card--d { grid-column: span 5; background: var(--white); }
-
-/* Card E — Full Stack, 7 cols, black */
-.bento-card--e { grid-column: span 7; background: var(--black); color: var(--white); }
-
-/* card label */
 .bento-card-label {
     font-family: var(--font-head);
     font-size: 0.78rem;
@@ -986,7 +943,6 @@ em   { font-style: italic; }
 
 .bento-card-label--light { color: var(--white); }
 
-/* large bg icon */
 .bento-icon-pop {
     position: absolute;
     bottom: -0.25rem;
@@ -998,12 +954,7 @@ em   { font-style: italic; }
     line-height: 1;
 }
 
-/* skill chips */
-.skill-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.6rem;
-}
+.skill-chips { display: flex; flex-wrap: wrap; gap: 0.6rem; }
 
 .chip {
     font-family: var(--font-body);
@@ -1019,10 +970,9 @@ em   { font-style: italic; }
     cursor: default;
 }
 
-.chip:hover                { transform: rotate(-2deg) scale(1.08); background: var(--green); }
-.chip--purple:hover        { background: var(--purple); color: var(--white); }
+.chip:hover         { transform: rotate(-2deg) scale(1.08); background: var(--green); }
+.chip--purple:hover { background: var(--purple); color: var(--white); }
 
-/* neon list in card B */
 .neon-list {
     list-style: none;
     display: flex;
@@ -1042,7 +992,6 @@ em   { font-style: italic; }
 
 .neon-dot { color: var(--green); font-size: 0.65rem; }
 
-/* cert dashboard inside card C */
 .cert-dashboard {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
@@ -1086,12 +1035,7 @@ em   { font-style: italic; }
     line-height: 1.35;
 }
 
-/* stack pills in card E */
-.stack-pills {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.6rem;
-}
+.stack-pills { display: flex; flex-wrap: wrap; gap: 0.6rem; }
 
 .stack-pill {
     font-family: var(--font-body);
@@ -1140,7 +1084,6 @@ em   { font-style: italic; }
     transition:
         transform   0.35s var(--bounce),
         box-shadow  0.35s var(--bounce);
-    /* scroll entrance */
     opacity: 0;
 }
 
@@ -1200,11 +1143,7 @@ em   { font-style: italic; }
     box-shadow: 2px 2px 0px var(--black);
 }
 
-.project-btns {
-    display: flex;
-    gap: 0.7rem;
-    flex-wrap: wrap;
-}
+.project-btns { display: flex; gap: 0.7rem; flex-wrap: wrap; }
 
 
 /* ══════════════════════════════════════════════════════════════
@@ -1216,9 +1155,7 @@ em   { font-style: italic; }
     border-top: var(--border);
 }
 
-.blogs-section .section-header {
-    margin-bottom: 3rem;
-}
+.blogs-section .section-header { margin-bottom: 3rem; }
 
 .blogs-gallery-wrapper {
     position: relative;
@@ -1236,14 +1173,11 @@ em   { font-style: italic; }
     display: flex;
     gap: 1.5rem;
     padding: 1rem 0;
-    /* Hide scrollbar */
     -ms-overflow-style: none;
     scrollbar-width: none;
 }
 
-.blogs-gallery::-webkit-scrollbar {
-    display: none;
-}
+.blogs-gallery::-webkit-scrollbar { display: none; }
 
 .blog-card {
     flex: 0 0 350px;
@@ -1257,9 +1191,7 @@ em   { font-style: italic; }
     object-fit: cover;
 }
 
-.blog-card-content {
-    min-height: 255px;
-}
+.blog-card-content { min-height: 275px; }
 
 .blog-card-title {
     display: -webkit-box;
@@ -1267,20 +1199,52 @@ em   { font-style: italic; }
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    margin-bottom: 0.5rem;
 }
+
+/* ── Blog stats row ─────────────────────────────────────────── */
+.blog-card-stats {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.65rem;
+    flex-wrap: wrap;
+}
+
+.blog-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-family: var(--font-body);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: lowercase;
+    letter-spacing: 0.02em;
+    padding: 0.2rem 0.6rem;
+    border-radius: var(--radius-pill);
+    border: 2px solid var(--black);
+    box-shadow: 2px 2px 0px var(--black);
+    white-space: nowrap;
+}
+
+.blog-stat svg { flex-shrink: 0; }
+
+.blog-stat--time {
+    background: var(--black);
+    color: var(--green);
+    border-color: var(--black);
+}
+
+/* ── End blog stats ─────────────────────────────────────────── */
 
 .blog-card-description {
     min-height: 72px;
     margin-bottom: 1.1rem;
 }
 
-.blog-card-tags {
-    margin-bottom: 1.1rem;
-}
+.blog-card-tags { margin-bottom: 1.1rem; }
 
-.blog-card-footer {
-    margin-top: auto;
-}
+.blog-card-footer { margin-top: auto; }
 
 .blogs-loading {
     flex: 0 0 100%;
@@ -1293,7 +1257,6 @@ em   { font-style: italic; }
     font-size: 1rem;
 }
 
-/* Gallery Navigation */
 .gallery-nav {
     width: 44px;
     height: 44px;
@@ -1311,83 +1274,29 @@ em   { font-style: italic; }
     flex-shrink: 0;
 }
 
-.gallery-nav:hover {
-    background: var(--black);
-    color: var(--white);
-    transform: scale(1.08);
-}
+.gallery-nav:hover { background: var(--black); color: var(--white); transform: scale(1.08); }
+.gallery-nav:disabled { opacity: 0.3; cursor: not-allowed; }
+.gallery-nav:disabled:hover { background: var(--white); color: var(--black); transform: scale(1); }
 
-.gallery-nav:disabled {
-    opacity: 0.3;
-    cursor: not-allowed;
-}
+.blogs-footer { text-align: center; }
 
-.gallery-nav:disabled:hover {
-    background: var(--white);
-    color: var(--black);
-    transform: scale(1);
-}
-
-.blogs-footer {
-    text-align: center;
-}
-
-/* Responsive adjustments */
 @media (max-width: 768px) {
-    .blogs-gallery-wrapper {
-        gap: 0.75rem;
-    }
-
-    .blog-card {
-        flex: 0 0 300px;
-    }
-
-    .blog-card-image {
-        height: 150px;
-    }
-
-    .blog-card-content { min-height: 235px; }
-
-    .gallery-nav {
-        width: 40px;
-        height: 40px;
-        font-size: 0.9rem;
-        border-width: 2px;
-    }
+    .blogs-gallery-wrapper { gap: 0.75rem; }
+    .blog-card { flex: 0 0 300px; }
+    .blog-card-image { height: 150px; }
+    .blog-card-content { min-height: 255px; }
+    .gallery-nav { width: 40px; height: 40px; font-size: 0.9rem; border-width: 2px; }
 }
 
 @media (max-width: 480px) {
-    .blogs-section {
-        padding: 4rem 1rem 3rem;
-    }
-
-    .blogs-gallery {
-        gap: 1rem;
-        padding: 0.75rem 0;
-    }
-
-    .blog-card {
-        flex: 0 0 260px;
-    }
-
-    .blog-card-image {
-        height: 130px;
-    }
-
-    .blog-card-description {
-        min-height: 62px;
-    }
-
-    .blog-card-content { min-height: 218px; }
-
-    .gallery-nav {
-        width: 36px;
-        height: 36px;
-        font-size: 0.8rem;
-        border-width: 1.5px;
-    }
+    .blogs-section { padding: 4rem 1rem 3rem; }
+    .blogs-gallery { gap: 1rem; padding: 0.75rem 0; }
+    .blog-card { flex: 0 0 260px; }
+    .blog-card-image { height: 130px; }
+    .blog-card-description { min-height: 62px; }
+    .blog-card-content { min-height: 235px; }
+    .gallery-nav { width: 36px; height: 36px; font-size: 0.8rem; border-width: 1.5px; }
 }
-
 
 
 /* ══════════════════════════════════════════════════════════════
@@ -1482,7 +1391,6 @@ em   { font-style: italic; }
     overflow: hidden;
 }
 
-/* bg emoji stickers */
 .cta-sticker {
     position: absolute;
     font-size: 6rem;
@@ -1494,15 +1402,12 @@ em   { font-style: italic; }
     line-height: 1;
 }
 
-.cta-sticker-1 { top: 6%;   left: 5%;  animation-delay: 0s;    }
-.cta-sticker-2 { top: 8%;   right: 7%; animation-delay: 1s;    }
+.cta-sticker-1 { top: 6%;    left: 5%;   animation-delay: 0s;    }
+.cta-sticker-2 { top: 8%;    right: 7%;  animation-delay: 1s;    }
 .cta-sticker-3 { bottom: 14%; left: 14%; animation-delay: 2.2s; }
 .cta-sticker-4 { bottom: 5%;  right: 4%; animation-delay: 0.6s; }
 
-.cta-inner {
-    position: relative;
-    z-index: 1;
-}
+.cta-inner { position: relative; z-index: 1; }
 
 .cta-headline {
     font-family: var(--font-head);
@@ -1550,7 +1455,6 @@ em   { font-style: italic; }
     overflow: hidden;
 }
 
-/* giant watermark brand text */
 .footer-brand-bg {
     position: absolute;
     top: 50%;
@@ -1665,14 +1569,12 @@ em   { font-style: italic; }
    RESPONSIVE
 ══════════════════════════════════════════════════════════════ */
 
-/* ── Tablet (≤1100px) ── */
 @media (max-width: 1100px) {
     .bento-card--a { grid-column: span 7; }
     .bento-card--b { grid-column: span 5; }
     .cert-dashboard { grid-template-columns: repeat(4, 1fr); }
 }
 
-/* ── Small tablet (≤900px) ── */
 @media (max-width: 900px) {
     .hero {
         grid-template-columns: 1fr;
@@ -1681,66 +1583,49 @@ em   { font-style: italic; }
         padding-bottom: 4rem;
         gap: 2rem;
     }
-
     .hero-right { min-height: 380px; }
-
     .bento-grid { grid-template-columns: repeat(6, 1fr); }
     .bento-card--a { grid-column: span 6; }
     .bento-card--b { grid-column: span 6; }
     .bento-card--c { grid-column: span 6; }
     .bento-card--d { grid-column: span 3; }
     .bento-card--e { grid-column: span 3; }
-
     .about-grid { grid-template-columns: 1fr; text-align: center; }
     .about-photo { width: 100%; max-width: 260px; height: 300px; }
     .about-photo-wrap { display: flex; justify-content: center; }
     .about-badges { justify-content: center; }
-
     .projects-grid { grid-template-columns: 1fr 1fr; }
     .cert-dashboard { grid-template-columns: repeat(2, 1fr); }
-
-    .nav-links   { display: none; }
+    .nav-links    { display: none; }
     .nav-cta-pill { display: none; }
     .nav-hamburger { display: flex; }
-
     .footer-inner { flex-direction: column; align-items: flex-start; gap: 1.5rem; }
     .footer-nav   { gap: 1rem; }
 }
 
-/* ── Mobile (≤600px) ── */
 @media (max-width: 600px) {
     .hero { padding: 7rem 5% 3.5rem; }
     .hero-headline { font-size: clamp(2.8rem, 12vw, 4rem); }
     .hero-cta-row  { flex-direction: column; }
     .hero-right    { min-height: 340px; }
-
-    .phone-frame { width: 230px; }
+    .phone-frame  { width: 230px; }
     .phone-screen { min-height: 390px; }
-
     .projects-grid { grid-template-columns: 1fr; }
-
     .bento-grid { grid-template-columns: 1fr; }
     .bento-card--a,
     .bento-card--b,
     .bento-card--c,
     .bento-card--d,
     .bento-card--e { grid-column: span 1; }
-
     .cert-dashboard { grid-template-columns: repeat(2, 1fr); }
-
     .cta-headline { font-size: clamp(2.5rem, 13vw, 4rem); }
     .cta-headline--outline { -webkit-text-stroke: 2px var(--white); }
-
     .marquee-outer { width: 112%; margin: 2rem -6%; }
     .marquee-track span { font-size: 1.1rem; }
-
     .bento-section,
     .projects-section,
     .faq-section,
     .about-section { padding-left: 5%; padding-right: 5%; }
-
     .footer-brand-bg { font-size: 14vw; }
-
-    /* Hide glow on touch devices */
     .hero-cursor-glow { display: none; }
 }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@
 (function initMarquee() {
     var track = document.getElementById('marquee-track');
     if (!track) return;
-    // Clone once so we have exactly 2× content; CSS animates -50%
     track.innerHTML += track.innerHTML;
 })();
 
@@ -26,8 +25,6 @@ function resetMobileNavForDesktop() {
     var overlay = document.getElementById('mobile-overlay');
     var drawer = document.getElementById('mobile-drawer');
     if (!overlay || !drawer) return;
-
-    // Keep drawer state clean when switching back to desktop layout.
     if (window.innerWidth > 900) {
         drawer.classList.remove('open');
         overlay.classList.remove('visible');
@@ -38,7 +35,6 @@ function resetMobileNavForDesktop() {
 window.addEventListener('resize', resetMobileNavForDesktop, { passive: true });
 document.addEventListener('DOMContentLoaded', resetMobileNavForDesktop);
 
-// Close on Escape
 document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') {
         var drawer = document.getElementById('mobile-drawer');
@@ -61,10 +57,7 @@ document.addEventListener('keydown', function (e) {
     var logoMark = document.querySelector('.nav-logo-link .logo-mark');
     var logoLink = document.querySelector('.nav-logo-link');
 
-    if (!gsapRef) {
-        // Graceful fallback when GSAP fails to load.
-        return;
-    }
+    if (!gsapRef) return;
 
     var tlRefs = [];
     var activeTweenRefs = [];
@@ -145,9 +138,7 @@ document.addEventListener('keydown', function (e) {
                 duration: 0.8,
                 ease: 'elastic.out(1,0.5)',
                 overwrite: 'auto',
-                onComplete: function () {
-                    gsapRef.set(logoMark, { rotate: 0 });
-                }
+                onComplete: function () { gsapRef.set(logoMark, { rotate: 0 }); }
             });
         });
     }
@@ -155,7 +146,6 @@ document.addEventListener('keydown', function (e) {
     window.addEventListener('resize', buildTimelines, { passive: true });
     document.addEventListener('DOMContentLoaded', buildTimelines);
 
-    // Keep nav animation synced with active class updates from section observer.
     var obs = new MutationObserver(syncActivePills);
     links.forEach(function (link) {
         obs.observe(link, { attributes: true, attributeFilter: ['class'] });
@@ -198,13 +188,9 @@ document.addEventListener('keydown', function (e) {
     function updateActiveFromScroll() {
         var scrollPos = window.scrollY + 170;
         var currentId = sections[0].id;
-
         sections.forEach(function (section) {
-            if (scrollPos >= section.offsetTop) {
-                currentId = section.id;
-            }
+            if (scrollPos >= section.offsetTop) currentId = section.id;
         });
-
         setActiveById(currentId);
     }
 
@@ -222,7 +208,6 @@ document.addEventListener('keydown', function (e) {
     );
     if (!targets.length) return;
 
-    // Stagger delays for grouped elements
     document.querySelectorAll('.bento-card').forEach(function (el, i) {
         el.style.animationDelay = (i * 0.07) + 's';
     });
@@ -246,27 +231,22 @@ document.addEventListener('keydown', function (e) {
 })();
 
 
-/* ── FAQ — prevent default summary toggle jank on fast clicks ─ */
+/* ── FAQ ─────────────────────────────────────────────────────── */
 (function initFaq() {
     var items = document.querySelectorAll('.faq-item');
     items.forEach(function (item) {
         var summary = item.querySelector('.faq-summary');
         if (!summary) return;
-        // Let native <details> handle open/close;
-        // we just ensure smooth icon transition via CSS.
         summary.addEventListener('click', function () {
-            // Close others for accordion feel (optional)
             items.forEach(function (other) {
-                if (other !== item && other.open) {
-                    other.open = false;
-                }
+                if (other !== item && other.open) other.open = false;
             });
         });
     });
 })();
 
 
-/* ── HERO ENTRANCE — stagger left-side children ─────────────── */
+/* ── HERO ENTRANCE ───────────────────────────────────────────── */
 (function initHeroEntrance() {
     var heroLeft = document.querySelector('.hero-left');
     if (!heroLeft) return;
@@ -276,7 +256,6 @@ document.addEventListener('keydown', function (e) {
         child.style.transition =
             'opacity 0.55s ease ' + (0.1 + i * 0.12) + 's, ' +
             'transform 0.55s cubic-bezier(0.175, 0.885, 0.32, 1.275) ' + (0.1 + i * 0.12) + 's';
-        // Trigger reflow then animate in
         requestAnimationFrame(function () {
             requestAnimationFrame(function () {
                 child.style.opacity   = '1';
@@ -287,7 +266,7 @@ document.addEventListener('keydown', function (e) {
 })();
 
 
-/* ── HERO ROLE ROTATOR — dynamic modern subtitle ───────────── */
+/* ── HERO ROLE ROTATOR ───────────────────────────────────────── */
 (function initHeroRoleRotator() {
     var roleEl = document.getElementById('hero-role-text');
     if (!roleEl) return;
@@ -302,7 +281,6 @@ document.addEventListener('keydown', function (e) {
     var idx = 0;
     setInterval(function () {
         roleEl.classList.add('is-swapping');
-
         setTimeout(function () {
             idx = (idx + 1) % roles.length;
             roleEl.textContent = roles[idx];
@@ -316,8 +294,6 @@ document.addEventListener('keydown', function (e) {
 (function initHeroCursorGlow() {
     var hero = document.querySelector('.hero');
     if (!hero) return;
-
-    // Skip on touch-only devices
     if (window.matchMedia('(hover: none)').matches) return;
 
     var glow = document.createElement('div');
@@ -343,7 +319,6 @@ document.addEventListener('keydown', function (e) {
         var rect = hero.getBoundingClientRect();
         mouseX = e.clientX - rect.left;
         mouseY = e.clientY - rect.top;
-
         if (!isInside) {
             isInside = true;
             glowX = mouseX;
@@ -361,64 +336,84 @@ document.addEventListener('keydown', function (e) {
 })();
 
 
-/* ── MEDIUM BLOGS GALLERY — horizontal scrollable card deck ───────────── */
+/* ── MEDIUM BLOGS GALLERY ────────────────────────────────────── */
 (function initBlogsGallery() {
-    var gallery = document.getElementById('blogsGallery');
+    var gallery       = document.getElementById('blogsGallery');
     var scrollLeftBtn = document.getElementById('blogsScrollLeft');
-    var scrollRightBtn = document.getElementById('blogsScrollRight');
-    
+    var scrollRightBtn= document.getElementById('blogsScrollRight');
     if (!gallery) return;
 
-    var feedUrl = 'https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/@rushpatel';
-    var scrollAmount = 380; // Card width + gap
+    var feedUrl     = 'https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/@rushpatel';
+    var scrollAmount = 380;
 
-    function fetchBlogs() {
-        fetch(feedUrl)
-            .then(response => response.json())
-            .then(data => {
-                if (data.status === 'ok' && data.items && data.items.length > 0) {
-                    var articles = data.items.slice(0, 6);
-                    renderCards(articles);
-                } else {
-                    gallery.innerHTML = '<div class="blogs-loading">No articles found yet.</div>';
-                }
-            })
-            .catch(error => {
-                console.error('Error fetching Medium feed:', error);
-                gallery.innerHTML = '<div class="blogs-loading">Unable to load articles. Please check back later.</div>';
-            });
+    /* ── Helpers ── */
+    function estimateReadTime(html) {
+        var text  = html.replace(/<[^>]*>/g, ' ');
+        var words = text.trim().split(/\s+/).filter(Boolean).length;
+        var mins  = Math.max(1, Math.round(words / 200));
+        return mins + ' min read';
     }
 
+    function getRealCategories(article) {
+        var cats = [];
+        if (Array.isArray(article.categories) && article.categories.length) {
+            // RSS returns lowercase strings; sanitise and take up to 3
+            cats = article.categories
+                .map(function (c) { return c.toLowerCase().trim(); })
+                .filter(function (c) { return c.length > 0 && c.length < 22; })
+                .slice(0, 3);
+        }
+        // Fallback: derive from title keywords if API returned nothing
+        if (!cats.length) {
+            var t = (article.title || '').toLowerCase();
+            if (t.includes('devops'))     cats.push('devops');
+            if (t.includes('kubernetes') || t.includes('k8s')) cats.push('k8s');
+            if (t.includes('cloud'))      cats.push('cloud');
+            if (t.includes('terraform'))  cats.push('terraform');
+            if (t.includes('aws'))        cats.push('aws');
+            if (!cats.length)             cats.push('article');
+        }
+        return cats;
+    }
+
+    /* ── Card builder ── */
     function createCard(article) {
-        var cleanDescription = article.description
+        var cleanDescription = (article.description || '')
             .replace(/<[^>]*>/g, '')
             .slice(0, 100);
 
-        // Extract image from article content if available
-        var imageMatch = article.description && article.description.match(/<img[^>]+src=["']([^"']+)["']/);
-        var imageUrl = imageMatch ? imageMatch[1] : 'https://via.placeholder.com/350x200?text=' + encodeURIComponent(article.title.slice(0, 20));
+        var imageMatch = article.description &&
+            article.description.match(/<img[^>]+src=["']([^"']+)["']/);
+        var imageUrl = imageMatch
+            ? imageMatch[1]
+            : 'https://via.placeholder.com/350x200?text=' +
+              encodeURIComponent((article.title || '').slice(0, 20));
 
-        // Default category based on keywords (could be enhanced)
-        var categories = ['article', 'insights'];
-        if (article.title.toLowerCase().includes('devops')) categories.push('devops');
-        if (article.title.toLowerCase().includes('kubernetes')) categories.push('k8s');
-        if (article.title.toLowerCase().includes('cloud')) categories.push('cloud');
-        categories = categories.slice(-2); // Keep last 2
+        var readTime   = estimateReadTime(article.description || '');
+        var categories = getRealCategories(article);
 
         var card = document.createElement('div');
         card.className = 'blog-card project-card';
 
         card.innerHTML = `
             <img src="${imageUrl}" alt="${article.title}" class="blog-card-image project-img" loading="lazy" decoding="async">
-            
+
             <div class="blog-card-content project-info">
                 <h3 class="blog-card-title project-title">${article.title}</h3>
+
+                <div class="blog-card-stats">
+                    <span class="blog-stat blog-stat--time">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                        ${readTime}
+                    </span>
+                </div>
+
                 <p class="blog-card-description project-desc">${cleanDescription}...</p>
-                
+
                 <div class="blog-card-tags project-tags">
                     ${categories.map(cat => `<span class="project-tag">${cat}</span>`).join('')}
                 </div>
-                
+
                 <div class="blog-card-footer project-btns">
                     <a href="${article.link}" target="_blank" rel="noopener noreferrer" class="btn-brutal btn-brutal--black">
                         read article
@@ -433,59 +428,51 @@ document.addEventListener('keydown', function (e) {
         return card;
     }
 
+    /* ── Fetch ── */
+    function fetchBlogs() {
+        fetch(feedUrl)
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (data.status === 'ok' && data.items && data.items.length) {
+                    renderCards(data.items.slice(0, 6));
+                } else {
+                    gallery.innerHTML = '<div class="blogs-loading">No articles found yet.</div>';
+                }
+            })
+            .catch(function (err) {
+                console.error('Error fetching Medium feed:', err);
+                gallery.innerHTML = '<div class="blogs-loading">Unable to load articles. Please check back later.</div>';
+            });
+    }
+
     function renderCards(articles) {
         gallery.innerHTML = '';
-        articles.forEach(function(article) {
+        articles.forEach(function (article) {
             gallery.appendChild(createCard(article));
         });
         updateScrollButtons();
     }
 
+    /* ── Scroll controls ── */
     function updateScrollButtons() {
-        var scrollLeft = gallery.scrollLeft;
-        var scrollWidth = gallery.scrollWidth;
-        var clientWidth = gallery.clientWidth;
-
-        // Disable left button if at start
-        if (scrollLeftBtn) {
-            scrollLeftBtn.disabled = scrollLeft === 0;
-        }
-
-        // Disable right button if at end
-        if (scrollRightBtn) {
-            scrollRightBtn.disabled = scrollLeft + clientWidth >= scrollWidth - 10;
-        }
+        var sl = gallery.scrollLeft;
+        var sw = gallery.scrollWidth;
+        var cw = gallery.clientWidth;
+        if (scrollLeftBtn)  scrollLeftBtn.disabled  = sl === 0;
+        if (scrollRightBtn) scrollRightBtn.disabled = sl + cw >= sw - 10;
     }
 
     function scroll(direction) {
-        var currentScroll = gallery.scrollLeft;
-        var targetScroll = currentScroll + (direction === 'left' ? -scrollAmount : scrollAmount);
-        
-        gsap.to(gallery, {
-            scrollLeft: targetScroll,
-            duration: 0.6,
-            ease: 'power2.inOut',
-            onUpdate: updateScrollButtons
-        });
+        var target = gallery.scrollLeft + (direction === 'left' ? -scrollAmount : scrollAmount);
+        gsap.to(gallery, { scrollLeft: target, duration: 0.6, ease: 'power2.inOut', onUpdate: updateScrollButtons });
     }
 
-    // Event listeners
-    if (scrollLeftBtn) {
-        scrollLeftBtn.addEventListener('click', function() {
-            scroll('left');
-        });
-    }
-
-    if (scrollRightBtn) {
-        scrollRightBtn.addEventListener('click', function() {
-            scroll('right');
-        });
-    }
+    if (scrollLeftBtn)  scrollLeftBtn.addEventListener('click',  function () { scroll('left');  });
+    if (scrollRightBtn) scrollRightBtn.addEventListener('click', function () { scroll('right'); });
 
     gallery.addEventListener('scroll', updateScrollButtons, { passive: true });
     window.addEventListener('resize', updateScrollButtons, { passive: true });
 
-    // Fetch blogs when DOM is ready
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', fetchBlogs);
     } else {


### PR DESCRIPTION
## What's changed

- **Read time (est.)** — each blog card now shows an estimated read time badge (e.g. `4 min read`) calculated from the article word count at ~200 wpm.
- **Real categories / tags** — tags are sourced directly from the Medium RSS `categories` field (your actual Medium tags), with a keyword-based title fallback if the API returns nothing.
- **New CSS** — `.blog-card-stats`, `.blog-stat`, `.blog-stat--time` pill styles consistent with the neo-brutalist design system (black bg, acid-green text).

## Files changed
- `index.js` — `estimateReadTime()`, `getRealCategories()` helpers + stats row injected in `createCard()`
- `index.css` — blog stats styles added under the BLOGS section