### PR TITLE
feat(migration): full portfolio — all sections as React components

### DIFF
--- a/horizon-app/app/layout.tsx
+++ b/horizon-app/app/layout.tsx
@@ -1,22 +1,72 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { Space_Grotesk, DM_Sans } from 'next/font/google'
 import './globals.css'
 
-const inter = Inter({ subsets: ['latin'] })
+const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-space',
+  display: 'swap',
+})
+
+const dmSans = DM_Sans({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  style: ['normal', 'italic'],
+  variable: '--font-dm',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
-  title: 'Horizon — Rushabh Patel',
-  description: 'Interactive 3D hero section built with Three.js + GSAP',
+  title: 'Rushabh Patel — DevOps Engineer',
+  description:
+    'Rushabh Patel is a DevOps Engineer and Cloud Architect specializing in AWS, Azure, Terraform, Kubernetes, CI/CD, and full-stack development.',
+  keywords:
+    'Rushabh Patel, DevOps Engineer, Cloud Architect, AWS, Azure, Terraform, Kubernetes, CI/CD, Full Stack Developer',
+  authors: [{ name: 'Rushabh Patel' }],
+  robots: 'index, follow, max-image-preview:large',
+  themeColor: '#0a0a0a',
+  openGraph: {
+    type: 'website',
+    title: 'Rushabh Patel — DevOps Engineer',
+    description: 'Portfolio of Rushabh Patel: DevOps Engineer, Cloud Architect, and Full-Stack Developer.',
+    images: [{ url: '/main.jpg' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Rushabh Patel — DevOps Engineer',
+    description: 'DevOps Engineer and Cloud Architect specializing in AWS, Azure, Terraform, and Kubernetes.',
+    images: ['/main.jpg'],
+  },
 }
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode
-}>) {
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Rushabh Patel',
+  jobTitle: 'DevOps Engineer',
+  description: 'DevOps Engineer and Cloud Architect specializing in AWS, Azure, Terraform, Kubernetes, and CI/CD.',
+  url: 'https://rushabhpatel.dev',
+  image: '/main.jpg',
+  homeLocation: { '@type': 'Country', name: 'Canada' },
+  sameAs: [
+    'https://www.linkedin.com/in/prushabh/',
+    'https://github.com/rush1998',
+    'https://medium.com/@rushpatel',
+  ],
+  knowsAbout: ['AWS', 'Azure', 'Terraform', 'Kubernetes', 'CI/CD', 'DevOps', 'Full Stack Development'],
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>{children}</body>
+    <html lang="en" className={`${spaceGrotesk.variable} ${dmSans.variable}`} suppressHydrationWarning>
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
+      <body>{children}</body>
     </html>
   )
 }

--- a/horizon-app/app/page.tsx
+++ b/horizon-app/app/page.tsx
@@ -1,9 +1,29 @@
-import { DemoOne } from '@/components/ui/demo'
+import NavPill from '@/components/NavPill'
+import HeroSection from '@/components/HeroSection'
+import MarqueeSection from '@/components/MarqueeSection'
+import AboutSection from '@/components/AboutSection'
+import SkillsSection from '@/components/SkillsSection'
+import ProjectsSection from '@/components/ProjectsSection'
+import BlogsSection from '@/components/BlogsSection'
+import FaqSection from '@/components/FaqSection'
+import CtaSection from '@/components/CtaSection'
+import Footer from '@/components/Footer'
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-black">
-      <DemoOne />
-    </main>
+    <>
+      <NavPill />
+      <main id="main-content">
+        <HeroSection />
+        <MarqueeSection />
+        <AboutSection />
+        <SkillsSection />
+        <ProjectsSection />
+        <BlogsSection />
+        <FaqSection />
+        <CtaSection />
+      </main>
+      <Footer />
+    </>
   )
 }

--- a/horizon-app/components/AboutSection.tsx
+++ b/horizon-app/components/AboutSection.tsx
@@ -1,0 +1,43 @@
+import Image from 'next/image'
+
+export default function AboutSection() {
+  return (
+    <section className="about-section" id="about">
+      <div className="section-header">
+        <span className="section-label">get to know me</span>
+        <h2 className="section-title">about me.</h2>
+      </div>
+      <div className="about-grid">
+        <div className="about-photo-wrap">
+          <Image
+            src="/main.jpg"
+            alt="Rushabh Patel"
+            width={400}
+            height={500}
+            className="about-photo"
+            loading="lazy"
+          />
+          <div className="sticker sticker-about-1" aria-hidden="true">🎓</div>
+          <div className="sticker sticker-about-2" aria-hidden="true">🌍</div>
+        </div>
+        <div className="about-text-wrap">
+          <p className="about-text">
+            hey! i&apos;m rushabh — a <strong>devops engineer &amp; cloud architect</strong> based in Canada.
+            i graduated with an MS in Informatics from <strong>Northeastern University</strong>
+            {' '}and a BE in Computer Science from <strong>GTU</strong>.
+          </p>
+          <p className="about-text">
+            i specialize in designing resilient cloud infrastructure, automating ci/cd pipelines,
+            and bridging the gap between dev teams and ops.
+            {' '}<strong>3+ years</strong> of building things that actually scale.
+          </p>
+          <div className="about-badges">
+            <span className="badge badge--green">ms informatics</span>
+            <span className="badge badge--purple">3+ yrs exp</span>
+            <span className="badge badge--orange">open to work</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/horizon-app/components/BlogsSection.tsx
+++ b/horizon-app/components/BlogsSection.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { gsap } from 'gsap'
+
+interface Article {
+  title: string
+  link: string
+  description: string
+  categories: string[]
+}
+
+function estimateReadTime(html: string): string {
+  const words = html.replace(/<[^>]*>/g, ' ').trim().split(/\s+/).filter(Boolean).length
+  return Math.max(1, Math.round(words / 200)) + ' min read'
+}
+
+function getRealCategories(article: Article): string[] {
+  if (article.categories?.length) {
+    const cats = article.categories
+      .map(c => c.toLowerCase().trim())
+      .filter(c => c.length > 0 && c.length < 22)
+      .slice(0, 3)
+    if (cats.length) return cats
+  }
+  const t = article.title.toLowerCase()
+  const fallback: string[] = []
+  if (t.includes('devops'))                       fallback.push('devops')
+  if (t.includes('kubernetes') || t.includes('k8s')) fallback.push('k8s')
+  if (t.includes('cloud'))                        fallback.push('cloud')
+  if (t.includes('terraform'))                    fallback.push('terraform')
+  if (t.includes('aws'))                          fallback.push('aws')
+  return fallback.length ? fallback : ['article']
+}
+
+export default function BlogsSection() {
+  const [articles, setArticles] = useState<Article[]>([])
+  const [loading, setLoading]   = useState(true)
+  const [error, setError]       = useState(false)
+  const galleryRef   = useRef<HTMLDivElement>(null)
+  const leftBtnRef   = useRef<HTMLButtonElement>(null)
+  const rightBtnRef  = useRef<HTMLButtonElement>(null)
+  const SCROLL_AMT   = 380
+
+  const updateButtons = useCallback(() => {
+    const g = galleryRef.current
+    if (!g || !leftBtnRef.current || !rightBtnRef.current) return
+    leftBtnRef.current.disabled  = g.scrollLeft === 0
+    rightBtnRef.current.disabled = g.scrollLeft + g.clientWidth >= g.scrollWidth - 10
+  }, [])
+
+  const scroll = (dir: 'left' | 'right') => {
+    const g = galleryRef.current
+    if (!g) return
+    const target = g.scrollLeft + (dir === 'left' ? -SCROLL_AMT : SCROLL_AMT)
+    gsap.to(g, { scrollLeft: target, duration: 0.6, ease: 'power2.inOut', onUpdate: updateButtons })
+  }
+
+  useEffect(() => {
+    fetch('https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/@rushpatel')
+      .then(r => r.json())
+      .then(data => {
+        if (data.status === 'ok' && data.items?.length) {
+          setArticles(data.items.slice(0, 6))
+        } else {
+          setError(true)
+        }
+        setLoading(false)
+      })
+      .catch(() => { setError(true); setLoading(false) })
+  }, [])
+
+  useEffect(() => {
+    updateButtons()
+    const g = galleryRef.current
+    if (!g) return
+    g.addEventListener('scroll', updateButtons, { passive: true })
+    window.addEventListener('resize', updateButtons, { passive: true })
+    return () => {
+      g.removeEventListener('scroll', updateButtons)
+      window.removeEventListener('resize', updateButtons)
+    }
+  }, [articles, updateButtons])
+
+  return (
+    <section className="blogs-section" id="blogs">
+      <div className="section-header">
+        <span className="section-label">thoughts &amp; insights</span>
+        <h2 className="section-title">blogs.</h2>
+      </div>
+
+      <div className="blogs-gallery-wrapper">
+        <button ref={leftBtnRef}  className="gallery-nav gallery-nav--left"  aria-label="Scroll left"  onClick={() => scroll('left')}>&#8249;</button>
+
+        <div className="blogs-gallery" ref={galleryRef}>
+          {loading && (
+            <div className="blogs-loading">⏳ loading articles...</div>
+          )}
+          {error && !loading && (
+            <div className="blogs-loading">Unable to load articles. Please check back later.</div>
+          )}
+          {!loading && !error && articles.map(article => {
+            const imageMatch = article.description?.match(/<img[^>]+src=["']([^"']+)["']/)
+            const imageUrl   = imageMatch?.[1] ??
+              `https://via.placeholder.com/350x200?text=${encodeURIComponent(article.title.slice(0, 20))}`
+            const readTime   = estimateReadTime(article.description ?? '')
+            const categories = getRealCategories(article)
+            const cleanDesc  = (article.description ?? '').replace(/<[^>]*>/g, '').slice(0, 100)
+
+            return (
+              <div key={article.link} className="blog-card project-card">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={imageUrl} alt={article.title} className="blog-card-image project-img" loading="lazy" />
+                <div className="blog-card-content project-info">
+                  <h3 className="blog-card-title project-title">{article.title}</h3>
+                  <div className="blog-card-stats">
+                    <span className="blog-stat blog-stat--time">
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+                      </svg>
+                      {readTime}
+                    </span>
+                  </div>
+                  <p className="blog-card-description project-desc">{cleanDesc}...</p>
+                  <div className="blog-card-tags project-tags">
+                    {categories.map(cat => <span key={cat} className="project-tag">{cat}</span>)}
+                  </div>
+                  <div className="blog-card-footer project-btns">
+                    <a href={article.link} target="_blank" rel="noopener noreferrer" className="btn-brutal btn-brutal--black">read article</a>
+                    <a href={article.link} target="_blank" rel="noopener noreferrer" className="btn-brutal btn-brutal--white">medium</a>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <button ref={rightBtnRef} className="gallery-nav gallery-nav--right" aria-label="Scroll right" onClick={() => scroll('right')}>&#8250;</button>
+      </div>
+
+      <div className="blogs-footer">
+        <a href="https://medium.com/@rushpatel" target="_blank" rel="noopener noreferrer" className="btn-brutal btn-brutal--white wobble-btn">
+          ✍ read more on medium
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/horizon-app/components/CtaSection.tsx
+++ b/horizon-app/components/CtaSection.tsx
@@ -1,0 +1,24 @@
+export default function CtaSection() {
+  return (
+    <section className="cta-section" id="contact">
+      <span className="cta-sticker cta-sticker-1" aria-hidden="true">💣</span>
+      <span className="cta-sticker cta-sticker-2" aria-hidden="true">🦄</span>
+      <span className="cta-sticker cta-sticker-3" aria-hidden="true">⚡</span>
+      <span className="cta-sticker cta-sticker-4" aria-hidden="true">🌶️</span>
+      <div className="cta-inner">
+        <h2 className="cta-headline">let&apos;s build</h2>
+        <h2 className="cta-headline cta-headline--outline">something</h2>
+        <h2 className="cta-headline">wild.</h2>
+        <p className="cta-sub">i&apos;m available for full-time roles, consulting &amp; fun projects.</p>
+        <div className="cta-btns">
+          <a href="mailto:rushabh.patel1998@gmail.com" className="btn-brutal btn-brutal--black wobble-btn">
+            ✉ email me
+          </a>
+          <a href="https://www.linkedin.com/in/prushabh/" target="_blank" rel="noopener" className="btn-brutal btn-brutal--white wobble-btn">
+            in linkedin
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/horizon-app/components/FaqSection.tsx
+++ b/horizon-app/components/FaqSection.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useRef } from 'react'
+
+const FAQS = [
+  {
+    q: "what do you actually do every day?",
+    a: "mostly coffee + iac. i design cloud infra, write terraform modules, build ci/cd pipelines, and make sure deployments go out without drama. occasionally i also push real app code.",
+  },
+  {
+    q: "are you open to new opportunities?",
+    a: "yes! i'm actively exploring full-time devops / cloud engineering roles. contract work, consulting, and interesting side projects are all on the table. just reach out.",
+  },
+  {
+    q: "what's your cloud of choice?",
+    a: "aws is home base — i'm certified at solutions architect level. but i've shipped real workloads on azure too, and i believe in picking the right tool over platform loyalty.",
+  },
+  {
+    q: "can you help with my startup's infra?",
+    a: "absolutely. i love working with early-stage teams to lay the right foundations — scalable infra from day one so you're not scrambling when traction hits. drop me an email and let's talk specifics.",
+  },
+  {
+    q: "do you code frontend too?",
+    a: "yep — this very page is hand-coded by me. i'm comfortable across the full stack: html/css, javascript, react, node.js, and enough python to be dangerous.",
+  },
+]
+
+export default function FaqSection() {
+  const detailsRefs = useRef<(HTMLDetailsElement | null)[]>([])
+
+  const handleClick = (i: number) => {
+    detailsRefs.current.forEach((el, j) => {
+      if (el && j !== i && el.open) el.open = false
+    })
+  }
+
+  return (
+    <section className="faq-section" id="faq">
+      <div className="section-header">
+        <span className="section-label">got questions?</span>
+        <h2 className="section-title">faq.</h2>
+      </div>
+      <div className="faq-container">
+        {FAQS.map(({ q, a }, i) => (
+          <details
+            key={q}
+            className="faq-item"
+            ref={el => { detailsRefs.current[i] = el }}
+          >
+            <summary className="faq-summary" onClick={() => handleClick(i)}>
+              {q}
+              <span className="faq-icon" aria-hidden="true">+</span>
+            </summary>
+            <p className="faq-body">{a}</p>
+          </details>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/horizon-app/components/Footer.tsx
+++ b/horizon-app/components/Footer.tsx
@@ -1,0 +1,33 @@
+const FOOTER_LINKS = [
+  { href: '#about',    label: 'about' },
+  { href: '#skills',   label: 'skills' },
+  { href: '#projects', label: 'projects' },
+  { href: '#blogs',    label: 'blogs' },
+  { href: '#faq',      label: 'faq' },
+  { href: '#contact',  label: 'contact' },
+]
+
+export default function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="footer-brand-bg" aria-hidden="true">rushabh</div>
+      <div className="footer-inner">
+        <div className="footer-left">
+          <span className="footer-logo">RP</span>
+          <p className="footer-tagline">devops · cloud · full stack</p>
+        </div>
+        <nav className="footer-nav" aria-label="Footer navigation">
+          {FOOTER_LINKS.map(({ href, label }) => (
+            <a key={href} href={href}>{label}</a>
+          ))}
+        </nav>
+        <div className="footer-socials">
+          <a href="https://www.linkedin.com/in/prushabh/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn" className="footer-social-link">in</a>
+          <a href="https://github.com/rush1998"            target="_blank" rel="noopener noreferrer" aria-label="GitHub"   className="footer-social-link">gh</a>
+          <a href="https://medium.com/@rushpatel"          target="_blank" rel="noopener noreferrer" aria-label="Medium"   className="footer-social-link">md</a>
+        </div>
+      </div>
+      <p className="footer-legal">© 2026 rushabh patel. all rights reserved.</p>
+    </footer>
+  )
+}

--- a/horizon-app/components/HeroSection.tsx
+++ b/horizon-app/components/HeroSection.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Image from 'next/image'
+
+const ROLES = ['devops engineer', 'cloud architect', 'full-stack dev', 'automation-first builder']
+
+export default function HeroSection() {
+  const [roleIdx, setRoleIdx] = useState(0)
+  const [swapping, setSwapping] = useState(false)
+  const heroLeftRef = useRef<HTMLDivElement>(null)
+
+  // Role rotator
+  useEffect(() => {
+    const id = setInterval(() => {
+      setSwapping(true)
+      setTimeout(() => {
+        setRoleIdx(i => (i + 1) % ROLES.length)
+        setSwapping(false)
+      }, 220)
+    }, 2200)
+    return () => clearInterval(id)
+  }, [])
+
+  // Hero entrance animation
+  useEffect(() => {
+    const el = heroLeftRef.current
+    if (!el) return
+    Array.from(el.children).forEach((child, i) => {
+      const c = child as HTMLElement
+      c.style.opacity = '0'
+      c.style.transform = 'translateY(24px)'
+      c.style.transition = `opacity 0.55s ease ${0.1 + i * 0.12}s, transform 0.55s cubic-bezier(0.175,0.885,0.32,1.275) ${0.1 + i * 0.12}s`
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        c.style.opacity = '1'
+        c.style.transform = 'translateY(0)'
+      }))
+    })
+  }, [])
+
+  // Cursor glow
+  useEffect(() => {
+    const hero = document.querySelector<HTMLElement>('.hero')
+    if (!hero || window.matchMedia('(hover: none)').matches) return
+    const glow = document.createElement('div')
+    glow.className = 'hero-cursor-glow'
+    hero.appendChild(glow)
+    let mouseX = 0, mouseY = 0, glowX = 0, glowY = 0, rafId = 0, inside = false
+    const lerp = (a: number, b: number, t: number) => a + (b - a) * t
+    const animate = () => {
+      glowX = lerp(glowX, mouseX, 0.1)
+      glowY = lerp(glowY, mouseY, 0.1)
+      glow.style.left = glowX + 'px'
+      glow.style.top = glowY + 'px'
+      if (inside) rafId = requestAnimationFrame(animate)
+    }
+    const onMove = (e: MouseEvent) => {
+      const rect = hero.getBoundingClientRect()
+      mouseX = e.clientX - rect.left; mouseY = e.clientY - rect.top
+      if (!inside) { inside = true; glowX = mouseX; glowY = mouseY; glow.classList.add('visible'); rafId = requestAnimationFrame(animate) }
+    }
+    const onLeave = () => { inside = false; glow.classList.remove('visible'); cancelAnimationFrame(rafId) }
+    hero.addEventListener('mousemove', onMove, { passive: true })
+    hero.addEventListener('mouseleave', onLeave, { passive: true })
+    return () => {
+      hero.removeEventListener('mousemove', onMove)
+      hero.removeEventListener('mouseleave', onLeave)
+      glow.remove()
+    }
+  }, [])
+
+  return (
+    <section className="hero" id="hero">
+      <div className="hero-blob hero-blob--purple" aria-hidden="true" />
+      <div className="hero-blob hero-blob--pink"   aria-hidden="true" />
+
+      <div className="hero-left" ref={heroLeftRef}>
+        <span className="hero-eyebrow">👋 hey, i&apos;m</span>
+        <h1 className="hero-headline">
+          Rushabh<br />
+          <span className="gradient-text">Patel.</span>
+        </h1>
+        <p className="hero-sub">
+          <span className="hero-role-line">
+            <span className={`hero-role-text${swapping ? ' is-swapping' : ''}`}>
+              {ROLES[roleIdx]}
+            </span>
+            <span className="hero-role-cursor" aria-hidden="true" />
+          </span><br />
+          i build infrastructure that <em>doesn&apos;t</em> break at 3 am.
+        </p>
+        <div className="hero-cta-row">
+          <a href="/resume.pdf" target="_blank" rel="noopener" className="btn-brutal btn-brutal--black wobble-btn">
+            ↓ download cv
+          </a>
+          <a href="#contact" className="btn-brutal btn-brutal--white wobble-btn">
+            let&apos;s talk →
+          </a>
+        </div>
+        <div className="hero-socials">
+          <a href="https://www.linkedin.com/in/prushabh/" target="_blank" rel="noopener noreferrer" className="social-chip">
+            in linkedin
+          </a>
+          <a href="https://github.com/rush1998" target="_blank" rel="noopener noreferrer" className="social-chip">
+            ⌥ github
+          </a>
+          <a href="https://medium.com/@rushpatel" target="_blank" rel="noopener noreferrer" className="social-chip">
+            ✍ medium
+          </a>
+        </div>
+      </div>
+
+      <div className="hero-right">
+        {['☁️','⚡','🚀','🔥','✨'].map((emoji, i) => (
+          <div key={i} className={`sticker sticker-${i + 1}`} aria-hidden="true">{emoji}</div>
+        ))}
+        <div className="phone-mockup">
+          <div className="phone-frame">
+            <div className="phone-notch" />
+            <div className="phone-screen">
+              <div className="phone-header">
+                <span className="phone-header-title">my stack</span>
+                <span className="phone-header-badge">live</span>
+              </div>
+              <div className="phone-feed">
+                {[
+                  { cls: 'aws',   icon: '☁️', name: 'amazon web services', role: 'ec2 · s3 · lambda · eks' },
+                  { cls: 'tf',    icon: '🏗️', name: 'terraform / iac',       role: 'hashicorp certified' },
+                  { cls: 'k8s',   icon: '🐳', name: 'kubernetes',             role: 'eks · argocd · helm' },
+                  { cls: 'azure', icon: '🔷', name: 'microsoft azure',        role: 'entra id · monitor · networking' },
+                  { cls: 'dev',   icon: '💻', name: 'full stack',             role: 'js · node · react' },
+                ].map(({ cls, icon, name, role }) => (
+                  <div key={cls} className={`phone-post phone-post--${cls}`}>
+                    <span className="phone-post-icon">{icon}</span>
+                    <div>
+                      <div className="phone-post-name">{name}</div>
+                      <div className="phone-post-role">{role}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="phone-tabbar">
+                <span>🏠</span><span>🔍</span>
+                <span className="phone-tab-action">＋</span>
+                <span>📊</span><span>👤</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/horizon-app/components/MarqueeSection.tsx
+++ b/horizon-app/components/MarqueeSection.tsx
@@ -1,0 +1,24 @@
+const ITEMS = [
+  'devops engineer', 'cloud architect', 'terraform & aws',
+  'kubernetes fanatic', 'full stack dev', 'ci/cd pipelines',
+  'open source nerd', 'northeastern alum',
+]
+
+export default function MarqueeSection() {
+  // Duplicate items for seamless infinite loop (same as original JS)
+  const allItems = [...ITEMS, ...ITEMS]
+  return (
+    <div className="marquee-outer" aria-hidden="true">
+      <div className="marquee-wrap">
+        <div className="marquee-track">
+          {allItems.map((item, i) => (
+            <>
+              <span key={`item-${i}`}>{item}</span>
+              <span key={`sep-${i}`} className="marquee-sep">✦</span>
+            </>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/horizon-app/components/NavPill.tsx
+++ b/horizon-app/components/NavPill.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { gsap } from 'gsap'
+
+const NAV_LINKS = [
+  { href: '#about',    label: 'about' },
+  { href: '#skills',   label: 'skills' },
+  { href: '#projects', label: 'projects' },
+  { href: '#blogs',    label: 'blogs' },
+  { href: '#faq',      label: 'faq' },
+  { href: '#contact',  label: 'contact' },
+]
+
+export default function NavPill() {
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const [activeHref, setActiveHref] = useState('#about')
+  const [scrolled, setScrolled] = useState(false)
+  const navRef = useRef<HTMLElement>(null)
+  const linksRef = useRef<(HTMLAnchorElement | null)[]>([])
+  const tlRefs = useRef<gsap.core.Timeline[]>([])
+  const logoMarkRef = useRef<HTMLSpanElement>(null)
+
+  // Close drawer on resize to desktop
+  useEffect(() => {
+    const onResize = () => { if (window.innerWidth > 900) setMobileOpen(false) }
+    window.addEventListener('resize', onResize, { passive: true })
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  // Escape key closes drawer
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setMobileOpen(false) }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [])
+
+  // Lock body scroll when drawer open
+  useEffect(() => {
+    document.body.style.overflow = mobileOpen ? 'hidden' : ''
+    return () => { document.body.style.overflow = '' }
+  }, [mobileOpen])
+
+  // Scroll spy + pill shrink
+  useEffect(() => {
+    const sections = Array.from(document.querySelectorAll<HTMLElement>('section[id]'))
+    const onScroll = () => {
+      setScrolled(window.scrollY > 60)
+      const scrollPos = window.scrollY + 170
+      let current = sections[0]?.id ?? 'about'
+      sections.forEach(s => { if (scrollPos >= s.offsetTop) current = s.id })
+      setActiveHref('#' + current)
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    onScroll()
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  // GSAP pill hover animations
+  const buildTimelines = useCallback(() => {
+    tlRefs.current.forEach(tl => tl?.kill())
+    tlRefs.current = []
+    linksRef.current.forEach((link) => {
+      if (!link) return
+      const circle = link.querySelector<HTMLSpanElement>('.pill-hover-circle')
+      const label = link.querySelector<HTMLSpanElement>('.pill-label')
+      const labelHover = link.querySelector<HTMLSpanElement>('.pill-label-hover')
+      if (!circle || !label || !labelHover) return
+
+      const { width: w, height: h } = link.getBoundingClientRect()
+      const R = ((w * w) / 4 + h * h) / (2 * h)
+      const D = Math.ceil(2 * R) + 2
+      const delta = Math.ceil(R - Math.sqrt(Math.max(0, R * R - (w * w) / 4))) + 1
+
+      circle.style.width = D + 'px'
+      circle.style.height = D + 'px'
+      circle.style.bottom = '-' + delta + 'px'
+
+      gsap.set(circle, { xPercent: -50, scale: 0, transformOrigin: `50% ${D - delta}px` })
+      gsap.set(label, { y: 0 })
+      gsap.set(labelHover, { y: h + 10, opacity: 0 })
+
+      const tl = gsap.timeline({ paused: true })
+      tl.to(circle, { scale: 1.2, xPercent: -50, duration: 0.8, ease: 'power3.out' }, 0)
+        .to(label, { y: -(h + 8), duration: 0.6, ease: 'power3.out' }, 0)
+        .to(labelHover, { y: 0, opacity: 1, duration: 0.6, ease: 'power3.out' }, 0)
+      tlRefs.current.push(tl)
+    })
+  }, [])
+
+  useEffect(() => {
+    buildTimelines()
+    window.addEventListener('resize', buildTimelines, { passive: true })
+    return () => window.removeEventListener('resize', buildTimelines)
+  }, [buildTimelines])
+
+  const handleEnter = (i: number) => {
+    if (linksRef.current[i]?.classList.contains('active')) return
+    const tl = tlRefs.current[i]
+    if (tl) tl.tweenTo(tl.duration(), { duration: 0.4, ease: 'power3.out', overwrite: 'auto' })
+  }
+  const handleLeave = (i: number) => {
+    if (linksRef.current[i]?.classList.contains('active')) return
+    const tl = tlRefs.current[i]
+    if (tl) tl.tweenTo(0, { duration: 0.3, ease: 'power3.out', overwrite: 'auto' })
+  }
+
+  const onLogoEnter = () => {
+    if (logoMarkRef.current)
+      gsap.to(logoMarkRef.current, { rotate: 360, duration: 0.8, ease: 'elastic.out(1,0.5)',
+        onComplete: () => gsap.set(logoMarkRef.current, { rotate: 0 }) })
+  }
+
+  return (
+    <>
+      <nav
+        ref={navRef}
+        className="nav-pill"
+        id="nav-pill"
+        style={{
+          transform: scrolled ? 'translateX(-50%) scale(0.96)' : 'translateX(-50%) scale(1)',
+          boxShadow: scrolled ? '3px 3px 0px rgba(0,0,0,0.55)' : '4px 4px 0px #0a0a0a',
+        }}
+      >
+        <a href="#hero" className="nav-logo-link" onMouseEnter={onLogoEnter}>
+          <span ref={logoMarkRef} className="logo-mark">R</span>
+        </a>
+
+        <ul className="nav-links" id="nav-links">
+          {NAV_LINKS.map(({ href, label }, i) => (
+            <li key={href}>
+              <a
+                href={href}
+                ref={el => { linksRef.current[i] = el }}
+                className={`pill-link${activeHref === href ? ' active' : ''}`}
+                aria-label={`${label} section`}
+                onMouseEnter={() => handleEnter(i)}
+                onMouseLeave={() => handleLeave(i)}
+              >
+                <span className="pill-hover-circle" aria-hidden="true" />
+                <span className="label-stack">
+                  <span className="pill-label">{label}</span>
+                  <span className="pill-label-hover" aria-hidden="true">{label}</span>
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+
+        <a href="#contact" className="nav-cta-pill wobble-btn">get in touch</a>
+
+        <button
+          className="nav-hamburger"
+          id="nav-hamburger"
+          aria-label="open menu"
+          onClick={() => setMobileOpen(v => !v)}
+        >
+          <span /><span /><span />
+        </button>
+      </nav>
+
+      {/* Mobile overlay */}
+      <div
+        className={`mobile-nav-overlay${mobileOpen ? ' visible' : ''}`}
+        onClick={() => setMobileOpen(false)}
+      />
+
+      {/* Mobile drawer */}
+      <div className={`mobile-nav-drawer${mobileOpen ? ' open' : ''}`} id="mobile-drawer">
+        <button className="drawer-close-btn" onClick={() => setMobileOpen(false)} aria-label="close menu">
+          ✕
+        </button>
+        <ul>
+          {NAV_LINKS.map(({ href, label }) => (
+            <li key={href}>
+              <a href={href} onClick={() => setMobileOpen(false)}>{label}</a>
+            </li>
+          ))}
+          <li>
+            <a href="#contact" className="drawer-cta" onClick={() => setMobileOpen(false)}>get in touch →</a>
+          </li>
+        </ul>
+      </div>
+    </>
+  )
+}

--- a/horizon-app/components/ProjectsSection.tsx
+++ b/horizon-app/components/ProjectsSection.tsx
@@ -1,0 +1,63 @@
+import Image from 'next/image'
+
+const PROJECTS = [
+  {
+    img: '/Figma-site1.png',
+    alt: 'Experiential Network',
+    title: 'experiential network',
+    desc: 'A full-featured social platform designed for experiential learning communities with real-time collaboration features.',
+    tags: ['figma', 'ux/ui', 'react'],
+    github: 'https://github.com/rush1998',
+    demo: 'https://www.figma.com/proto/l86d06P47h7vPOUxMwnHGD/New-website?node-id=1-2&starting-point-node-id=1%3A2',
+    rot: '-2deg',
+  },
+  {
+    img: '/Figma-site2.png',
+    alt: 'Capstone Project',
+    title: 'capstone project',
+    desc: 'Graduate capstone — a platform bridging students and industry mentors with smart matching algorithms.',
+    tags: ['informatics', 'node.js', 'mongodb'],
+    github: 'https://github.com/rush1998',
+    demo: 'https://www.figma.com/proto/j9ZXbhAjOAdJmidsKjAC2i/ITC6040?node-id=1-4&starting-point-node-id=1%3A4',
+    rot: '1.5deg',
+  },
+  {
+    img: '/Figma-site3.png',
+    alt: 'E-commerce Website',
+    title: 'e-commerce site',
+    desc: 'Modern storefront with real-time inventory management, dynamic cart, and optimised checkout flow.',
+    tags: ['javascript', 'css', 'node.js'],
+    github: 'https://github.com/rush1998/Future_website.git',
+    demo: 'https://github.com/rush1998/Future_website.git',
+    rot: '-1deg',
+  },
+]
+
+export default function ProjectsSection() {
+  return (
+    <section className="projects-section" id="projects">
+      <div className="section-header">
+        <span className="section-label">what i&apos;ve built</span>
+        <h2 className="section-title">projects.</h2>
+      </div>
+      <div className="projects-grid">
+        {PROJECTS.map(({ img, alt, title, desc, tags, github, demo, rot }) => (
+          <div key={title} className="project-card" style={{ ['--rot' as string]: rot }}>
+            <Image src={img} alt={alt} width={600} height={340} className="project-img" loading="lazy" />
+            <div className="project-info">
+              <h3 className="project-title">{title}</h3>
+              <p className="project-desc">{desc}</p>
+              <div className="project-tags">
+                {tags.map(t => <span key={t} className="project-tag">{t}</span>)}
+              </div>
+              <div className="project-btns">
+                <a href={github} target="_blank" rel="noopener" className="btn-brutal btn-brutal--black">github</a>
+                <a href={demo}   target="_blank" rel="noopener" className="btn-brutal btn-brutal--white">live demo</a>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/horizon-app/components/SkillsSection.tsx
+++ b/horizon-app/components/SkillsSection.tsx
@@ -1,0 +1,78 @@
+import Image from 'next/image'
+
+const AWS_CHIPS = ['IAM','EC2','S3','Lambda','EKS','CloudWatch','CodePipeline','Cost Explorer']
+const DEVOPS_ITEMS = [
+  'Terraform / HCL','Kubernetes & Helm','ArgoCD / GitOps',
+  'Jenkins / GitHub Actions','Ansible / Puppet','Docker',
+]
+const AZURE_CHIPS = ['Entra ID','Azure Monitor','Cost Mgmt','Compute','Networking','Load Balancer']
+const STACK_PILLS = ['HTML','CSS','JavaScript','Node.js','React','MongoDB','Git','Python']
+const CERTS = [
+  { src: '/blob.png',   alt: 'HashiCorp Terraform',     label: 'HashiCorp Terraform' },
+  { src: '/aws-1.png',  alt: 'AWS Cloud Practitioner',  label: 'AWS Cloud Practitioner' },
+  { src: '/aws-2.png',  alt: 'AWS Solutions Architect', label: 'AWS Solutions Architect' },
+  { src: '/az-900.jpg', alt: 'Azure Fundamentals',      label: 'Azure Fundamentals' },
+]
+
+export default function SkillsSection() {
+  return (
+    <section className="bento-section" id="skills">
+      <div className="section-header">
+        <span className="section-label">what i know</span>
+        <h2 className="section-title">experience &amp; certs.</h2>
+      </div>
+      <div className="bento-grid">
+
+        {/* Card A: AWS */}
+        <div className="bento-card bento-card--a" style={{ ['--rot' as string]: '-1deg' }}>
+          <p className="bento-card-label">amazon web services</p>
+          <div className="skill-chips">
+            {AWS_CHIPS.map(c => <span key={c} className="chip">{c}</span>)}
+          </div>
+          <div className="bento-icon-pop" aria-hidden="true">☁️</div>
+        </div>
+
+        {/* Card B: DevOps Toolkit */}
+        <div className="bento-card bento-card--b" style={{ ['--rot' as string]: '2deg' }}>
+          <p className="bento-card-label bento-card-label--light">devops toolkit</p>
+          <ul className="neon-list">
+            {DEVOPS_ITEMS.map(item => (
+              <li key={item}><span className="neon-dot">✦</span> {item}</li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Card C: Certs */}
+        <div className="bento-card bento-card--c" style={{ ['--rot' as string]: '-0.5deg' }}>
+          <p className="bento-card-label bento-card-label--light">my certifications</p>
+          <div className="cert-dashboard">
+            {CERTS.map(({ src, alt, label }) => (
+              <div key={label} className="cert-item">
+                <Image src={src} alt={alt} width={60} height={60} className="cert-img" loading="lazy" />
+                <span>{label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Card D: Azure */}
+        <div className="bento-card bento-card--d" style={{ ['--rot' as string]: '1.5deg' }}>
+          <p className="bento-card-label">microsoft azure</p>
+          <div className="skill-chips">
+            {AZURE_CHIPS.map(c => <span key={c} className="chip chip--purple">{c}</span>)}
+          </div>
+          <div className="bento-icon-pop" aria-hidden="true">🔷</div>
+        </div>
+
+        {/* Card E: Full Stack */}
+        <div className="bento-card bento-card--e" style={{ ['--rot' as string]: '-2deg' }}>
+          <p className="bento-card-label bento-card-label--light">full stack dev</p>
+          <div className="stack-pills">
+            {STACK_PILLS.map(p => <span key={p} className="stack-pill">{p}</span>)}
+          </div>
+        </div>
+
+      </div>
+    </section>
+  )
+}

--- a/horizon-app/next.config.mjs
+++ b/horizon-app/next.config.mjs
@@ -1,3 +1,12 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
-export default nextConfig;
+const nextConfig = {
+  images: {
+    // Allow external Medium CDN images in BlogsSection
+    remotePatterns: [
+      { protocol: 'https', hostname: 'miro.medium.com' },
+      { protocol: 'https', hostname: 'cdn-images-1.medium.com' },
+      { protocol: 'https', hostname: 'via.placeholder.com' },
+    ],
+  },
+}
+export default nextConfig


### PR DESCRIPTION
## Full Next.js Migration

Converts the entire `index.html` + `index.js` portfolio into typed React Server/Client components inside `horizon-app/`.

---

## Components added

| Component | Type | Notes |
|---|---|---|
| `app/layout.tsx` | Server | Metadata, JSON-LD, next/font (Space Grotesk + DM Sans) |
| `app/page.tsx` | Server | Assembles all sections |
| `components/NavPill.tsx` | Client | GSAP pill hover, scroll spy, mobile drawer, Escape key |
| `components/HeroSection.tsx` | Client | Role rotator, entrance animation, cursor glow |
| `components/MarqueeSection.tsx` | Server | Infinite loop via duplicated items |
| `components/AboutSection.tsx` | Server | next/image optimised photo |
| `components/SkillsSection.tsx` | Server | Bento grid, all cert images via next/image |
| `components/ProjectsSection.tsx` | Server | 3 project cards, next/image |
| `components/BlogsSection.tsx` | Client | Medium RSS fetch, read time, categories, GSAP scroll |
| `components/FaqSection.tsx` | Client | Accordion, one-open-at-a-time |
| `components/CtaSection.tsx` | Server | Contact CTA |
| `components/Footer.tsx` | Server | Footer with brand bg |
| `next.config.mjs` | — | Remote image patterns for Medium CDN |

## One manual step required

Copy all image assets from the repo root into `horizon-app/public/`:
```
main.jpg, blob.png, aws-1.png, aws-2.png, az-900.jpg,
Figma-site1.png, Figma-site2.png, Figma-site3.png
```
Next.js serves `public/` as the root, so `/main.jpg` in `<Image src="/main.jpg">` maps to `public/main.jpg`.

## Run
```bash
cd horizon-app
npm install
npm run dev   # http://localhost:3000
```